### PR TITLE
add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Etsy Open Source Code of Conduct
+
+At Etsy, we are proud to say that we have an open source community that is welcoming, positive, and respectful to all participants, regardless of gender, gender identity, gender presentation, sexual orientation, race, age, disability, physical appearance, national origin, ethnicity, religion or any other protected status. We believe our diversity makes us stronger and enriches the work we do. In an effort to maintain a high level of respect and acceptance in our community, we ask that anyone who participates in Etsy’s open source community (https://github.com/etsy) follow this Code of Conduct.
+
+By participating in Etsy’s open source community, you agree to:
+- Treat each other with respect. This space and its related channels (such as pull requests, IRC channels, or mailing lists) may not be used to disparage another participant.
+- Respect each other’s privacy. Do not post another participant’s private or personally identifiable information in public spaces without their permission.
+- Respect each other’s boundaries. Do not use this space or any of its related channels to harass another participant.
+- Be thoughtful about what you say. Do not post content that promotes, supports, or glorifies hatred.
+- Be helpful. Offer constructive criticism or voice a dissenting opinion, but don’t be mean. Do not post threats of violence against others or promote or encourage others to engage in violence or illegal activity.
+- Be lawful. Don’t post, link or attach content that violates third party intellectual property rights, has malicious intent or interferes with the security of Etsy or contributors, violates the law, or violates Etsy’s Terms of Use when applicable.
+
+Examples of unacceptable behavior include, but are not limited to: offensive comments, verbal threats or demands, sexualized images, intimidation, stalking, sustained disruption of discussions, unwelcome sexual attention or approaches, violence, threats of violence, or violent or discriminatory language directed against another person or group.
+
+The safety of everyone in the community is of paramount importance. This means this is not the appropriate forum for:
+
+- Direct communication with a contributor once they have requested that you leave them alone (except for standard automated notifications as part of the contribution process); or,
+- Engaging in inflammatory debates, doxxing or trolling, regardless of subject.
+
+Discrimination, harassment or individual or coordinated attacks on contributors of any kind, whether directly or via ‘code language’ will not be tolerated.
+
+If you are being harassed or discriminated against, if you notice that someone else is being harassed or discriminated against, or if you have any other concerns, please contact a member of Etsy's team at [opensource-coc@etsy.com](mailto:opensource-coc@etsy.com). If a participant violates this Code of Conduct, Etsy may take any action we deem appropriate, including warning the offender, blocking them from the current project or all Etsy projects temporarily or permanently, and/or contacting law enforcement.


### PR DESCRIPTION
adds the contents of https://etsy.github.io/codeofconduct.html in markdown for use as the [default code of conduct](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) in all Etsy public github projects