### PR TITLE
feat: add initial default PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+> Please include a brief summary of the changes.
+
+## Context / Why are we making this change?
+
+> Please include details on why this change is necessary, and any applicable tickets, design docs, or documentation links.
+
+## Testing and QA Plan
+
+> How has this work been tested or QA'd?
+
+## Impact
+
+> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?


### PR DESCRIPTION
## Description

Adds a default PR template to our .github community repository. 

Introducing a `pull_request_template.md` file here means that any Etsy repository _which does not_ have its own file name `pull_request_template.md` will use this template. Repos that have their own templates will not be impacted. 

You can see the proposed template in use in this pull request!

## Context / Why are we making this change?

While many of our larger repositories do have PR templates, many of our smaller repos do not.

We believe that using a template is an easy way to help contributors write great and highly-reviewable pull requests. 

This was proposed at the AAG meet March 15, 2022.
[Orange doc: Default PR Templates at Etsy](https://docs.google.com/document/d/1e3Cg2LahlEjdvLxcSbtRYgvIQ--2b1Ivfg27GWR5rMk/edit#heading=h.z06865z8l0c8)

## Testing and QA Plan

After this PR is approved and merged, we'll make sure that the template is available in pull requests in other repos. 
We will collect feedback and iterate on the template as necessary.  

## Impact

This will be a noticeable change for many developers at Etsy, especially those who contribute to smaller repositories. 
Again, we'll collect feedback on the experience and iterate on the template as necessary. 