### PR TITLE
Add a link to go/inclusivecode to the default PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->
+
 ## Description
 
 > Please include a brief summary of the changes.


### PR DESCRIPTION
## Description

In a markdown comment, add a link to Etsy Engineering's code inclusivity principles to the default PR template.

## Context / Why are we making this change?

As the Inclusivity in Code Working Group rolls out the [code inclusivity principles](http://go/inclusivecode), we would like them to be easily accessible to Etsy engineers.

## Testing and QA Plan

I opened the template in a markdown previewer to verify the link is in a comment and not shown in the description output.

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?

We hope to lower the barrier to entry as much as possible for Etsians who need support in raising or responding to issues of code inclusivity.